### PR TITLE
Remove #attached of non-existant library

### DIFF
--- a/src/Form/MicroTypeFormController.php
+++ b/src/Form/MicroTypeFormController.php
@@ -61,9 +61,6 @@ class MicroTypeFormController extends EntityForm {
 
     $form['additional_settings'] = array(
       '#type' => 'vertical_tabs',
-      '#attached' => array(
-        'library' => array(array('micro', 'drupal.micro_types')),
-      ),
     );
 
     return $form;


### PR DESCRIPTION
The #attached is causing notices, because it is using the old array structure instead of `micro/drupal.micro_types`, but the library does not exist in the first place.
